### PR TITLE
Update Dynamicweb.DataIntegration.Providers.DynamicwebProvider.csproj

### DIFF
--- a/src/Dynamicweb.DataIntegration.Providers.DynamicwebProvider.csproj
+++ b/src/Dynamicweb.DataIntegration.Providers.DynamicwebProvider.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-    <Version>10.0.8</Version>
+    		<Version>10.0.9</Version>
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<Title>Dynamicweb Provider</Title>
 		<Description>Dynamicweb Provider</Description>
@@ -23,7 +23,7 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Dynamicweb.DataIntegration" Version="10.0.15" />
+		<PackageReference Include="Dynamicweb.DataIntegration" Version="10.0.17" />
 		<PackageReference Include="Dynamicweb.Ecommerce" Version="10.0.9" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>


### PR DESCRIPTION
Fixes method not found on various calls to BaseSqlProvider as it was changed to not return void

[AB#16293](https://dev.azure.com/dynamicwebsoftware/5a2edd81-7d89-4716-a4f3-1187ba91af92/_workitems/edit/16293)